### PR TITLE
Fixed hadatac-docker.conf and added it to the .gitignore file.

### DIFF
--- a/conf/.gitignore
+++ b/conf/.gitignore
@@ -1,4 +1,5 @@
 hadatac.conf
+hadatac-docker.conf
 labkey.config
 template.conf*
 play-authenticate/smtp.conf

--- a/conf/hadatac-docker.conf
+++ b/conf/hadatac-docker.conf
@@ -9,15 +9,14 @@ hadatac
 
     console
     {
-
-        # the application's base host URL
-        host="http://hadatac.org:9000"
-
-        # the url that the application is deployed
-        host_deploy="http://hadatac.org:9000"
-
         # the base url that the application uses to send email
         base_url="hadatac.org:9000"
+
+        # the application's base host URL
+        host="http://${hadatac.console.base_url}"
+
+        # the url that the application is deployed
+        host_deploy="http://${hadatac.console.base_url}"
 
         # the kb's base host URL -- usually, the application's base host URL without any port information
         kb="http://blazegraph"
@@ -33,7 +32,7 @@ hadatac
     {
 
         # HOME: the path in the file system where the SOLR instances are located
-        home=/var/hadatac/solr
+        home="/opt/solr/server"
 
         # URL for data collections
         data="http://solr:8983/solr"
@@ -46,7 +45,7 @@ hadatac
         users="http://solr:8983/solr"
 
         # URL for user permission management collection
-        permissions="http://blazegraph:9999/blazegraph/namespace"
+        permissions="http://blazegraph:9999/blazegraph/namespace/store_users"
     }
 
     # activity flags are used to verify if HADatAc knowledge base contains
@@ -62,16 +61,16 @@ hadatac
     }
 
     # properties about community using current HADatAc installation
-    #  - these properties are used to project customization of HADaAc installations
+    #  - these properties are used for project customization of HADaAc installations
     community
     {
-        fullname="Human-Aware Data Acquisition Framework Docker"
+        fullname="Human-Aware Data Acquisition Framework"
 
-        shortname="HADatAc Docker"
+        shortname="HADatAc"
 
-        description="This is a generic Human-Aware Data Acquisition framework installation using Docker as the deployment strategy."
+        description="This is a generic Human-Aware Data Acquisition framework installation."
 
-        ont_prefix="docker"
+        ont_prefix="generic"
     }
 
 }


### PR DESCRIPTION
The `conf/hadatac-docker.conf` file, which is copied over to the Play application's Docker container on build time has been updated. There was a problem with the `hadatac.solr.permissions` key that I fixed.

I also added it to the `.gitignore` file to prevent changes.

I tested re-building the Docker containers with the new hadatac-docker.conf file and it still works.