### PR TITLE
new fix for the sibling issue after the discussion with Paulo

### DIFF
--- a/app/org/hadatac/data/loader/MeasurementGenerator.java
+++ b/app/org/hadatac/data/loader/MeasurementGenerator.java
@@ -470,16 +470,15 @@ public class MeasurementGenerator extends BaseGenerator {
 
                 	measurement.setOriginalId(id);
                     reference = dasa.getObjectViewLabel();
-                    objUri = this.getObjectUri(id, reference, objList);
+                    measurement.setEntryObjectUri(this.getEntryObjectUri(id,objList));
+                    // objUri = this.getObjectUri(id, reference, objList);
 
                     if (reference != null && !reference.equals("")) {
                         if (objList.get(reference) == null) {
                             System.out.println("MeasurementGenerator: [ERROR] Processing objList for reference [" + reference + "]");
-                        } else if ( objUri == null ) {
-                            System.out.println("MeasurementGenerator: [ERROR] Processing subject with id [" + id + "]: cannot find its full URI");
                         } else {
                             // from object list
-                            // objUri = objList.get(reference).get(StudyObject.STUDY_OBJECT_URI);
+                            objUri = objList.get(reference).get(StudyObject.STUDY_OBJECT_URI);
                             measurement.setObjectUri(objUri);
                             measurement.setObjectCollectionType(objList.get(reference).get(StudyObject.SOC_TYPE));
                             measurement.setRole(objList.get(reference).get(StudyObject.SOC_LABEL));
@@ -804,15 +803,10 @@ public class MeasurementGenerator extends BaseGenerator {
     }
 
     // helper method to get the full URI of the VC object for a given originalId
-    private String getObjectUri(String id, String reference, Map<String, Map<String,String>> objList ) {
+    private String getEntryObjectUri(String id, Map<String, Map<String,String>> objList ) {
 
         if ( id == null || id.length() == 0 ) return null;
         if ( objList == null || objList.size() == 0 ) return null;
-
-        String role = objList.get(reference).get(StudyObject.SOC_LABEL);
-        if ( role != null && role.toLowerCase().indexOf("mother") < 0 ) { // this is hard-coded for now
-            return objList.get(reference).get(StudyObject.STUDY_OBJECT_URI);
-        }
 
         for (Map.Entry<String, Map<String,String>> entrySet : objList.entrySet() ) {
             Map map = entrySet.getValue();
@@ -832,3 +826,4 @@ public class MeasurementGenerator extends BaseGenerator {
         return "";
     }
 }
+

--- a/app/org/hadatac/entity/pojo/Measurement.java
+++ b/app/org/hadatac/entity/pojo/Measurement.java
@@ -61,6 +61,8 @@ public class Measurement extends HADatAcThing implements Runnable {
     private String objectUri;
     @Field("study_object_uri_str")
     private String studyObjectUri;
+    @Field("entry_object_uri_str")
+    private String entryObjectUri;
     @Field("study_object_type_uri_str")
     private String studyObjectTypeUri;
     @Field("timestamp_date")
@@ -171,6 +173,14 @@ public class Measurement extends HADatAcThing implements Runnable {
 
     public void setStudyObjectUri(String studyObjectUri) {
         this.studyObjectUri = studyObjectUri;
+    }
+
+    public String getEntryObjectUri() {
+        return entryObjectUri;
+    }
+
+    public void setEntryObjectUri(String entryObjectUri) {
+        this.entryObjectUri = entryObjectUri;
     }
 
     public String getStudyObjectTypeUri() {
@@ -1013,6 +1023,7 @@ public class Measurement extends HADatAcThing implements Runnable {
         m.setDasoUri(SolrUtils.getFieldValue(doc, "daso_uri_str"));
         m.setDasaUri(SolrUtils.getFieldValue(doc, "dasa_uri_str"));
         m.setStudyObjectUri(SolrUtils.getFieldValue(doc, "study_object_uri_str"));
+        m.setEntryObjectUri(SolrUtils.getFieldValue(doc, "entry_object_uri_str"));
         m.setStudyObjectTypeUri(SolrUtils.getFieldValue(doc, "study_object_type_uri_str"));
         m.setObjectUri(SolrUtils.getFieldValue(doc, "object_uri_str"));
         m.setRole(SolrUtils.getFieldValue(doc, "role_str"));
@@ -1184,11 +1195,11 @@ public class Measurement extends HADatAcThing implements Runnable {
                     //   - add entity-role to the collection of entity-roles of the alignment
                     //   - add object to the collection of objects of the alignment 
                 
-                	List<String> alignObjs = alignCache.get(m.getObjectUri()); 
+                	List<String> alignObjs = alignCache.get(m.getEntryObjectUri());
                 	if (alignObjs == null) {
-                		alignObjs = Alignment.alignmentObjects(m.getObjectUri(), selectedRole, m.getOriginalId());
+                		alignObjs = Alignment.alignmentObjects(m.getEntryObjectUri(), selectedRole, m.getOriginalId());
                 		if (alignObjs != null) {
-                			alignCache.put(m.getObjectUri(),alignObjs);
+                			alignCache.put(m.getEntryObjectUri(),alignObjs);
                 			/*
                 			System.out.print("Main object: [" + m.getObjectUri() + "] Associated Objects: [ ");
                 			for (String aux : alignObjs) {
@@ -1837,3 +1848,4 @@ public class Measurement extends HADatAcThing implements Runnable {
 
     }
 }
+


### PR DESCRIPTION
this is the continuation of the fix for the sibling issue after our 12:30pm discussion. The main fix was to add a entryObjectUri, which represents the URI for the object identified by the originalID. two files are changed for this fix. 