### PR TITLE
this is to fix the missing unit in the column header when downloading…

### DIFF
--- a/app/org/hadatac/entity/pojo/DataAcquisitionSchemaAttribute.java
+++ b/app/org/hadatac/entity/pojo/DataAcquisitionSchemaAttribute.java
@@ -604,6 +604,7 @@ public class DataAcquisitionSchemaAttribute extends HADatAcThing {
         String inRelationToUri = "";
         String relationUri = "";
 
+        Map<String,String> relationMap = new HashMap<>();
         while (resultsrw.hasNext()) {        	
             QuerySolution soln = resultsrw.next();
 
@@ -639,6 +640,12 @@ public class DataAcquisitionSchemaAttribute extends HADatAcThing {
                 relationUri = soln.get("relation").toString();
             }
 
+            if ( relationUri != null && relationUri.length() > 0 && inRelationToUri != null && inRelationToUri.length() > 0 ) {
+                relationMap.put(relationUri, inRelationToUri);
+                relationUri = "";
+                inRelationToUri = "";
+            }
+
         }
 
         dasa = new DataAcquisitionSchemaAttribute(
@@ -653,9 +660,11 @@ public class DataAcquisitionSchemaAttribute extends HADatAcThing {
                 daseUriStr,
                 dasoUriStr);
 
-        dasa.addRelation(relationUri, inRelationToUri);
+        for ( Map.Entry<String, String> entry : relationMap.entrySet() ) {
+            dasa.addRelation(entry.getKey(), entry.getValue());
+        }
 
-	DataAcquisitionSchemaAttribute.getCache().put(dasa_uri,dasa);
+	    DataAcquisitionSchemaAttribute.getCache().put(dasa_uri,dasa);
         return dasa;
     }
 
@@ -926,3 +935,5 @@ public class DataAcquisitionSchemaAttribute extends HADatAcThing {
         return 0;
     }
 }
+
+


### PR DESCRIPTION
This is to solve the problem where the unit is missing from the column header when downloading file. Root cause: a given DASA can have more than one relations (relation/inRelationTo), therefore adding a map to collect all of these relations. The current way of parsing the DASA relations only keeps the very last one (overriding the previous ones). 