### PR TITLE
remove the log filter

### DIFF
--- a/app/org/hadatac/console/controllers/dataacquisitionsearch/DataAcquisitionSearch.java
+++ b/app/org/hadatac/console/controllers/dataacquisitionsearch/DataAcquisitionSearch.java
@@ -28,7 +28,6 @@ import org.hadatac.console.models.ObjectDetails;
 import org.hadatac.console.models.Pivot;
 
 import org.hadatac.entity.pojo.*;
-import org.hadatac.filters.MyLoggingFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.libs.concurrent.HttpExecutionContext;


### PR DESCRIPTION
Sorry Paulo for the extra merge - I used a log filter of my own to debug the issue, and accidentally included the log filter into the pull request, so need to get rid of it. But we might eventually want to include this log filter, so we know "which user called which functionality and how long the call took".