### PR TITLE
handling the production performance issue by improving SPARQL queries

### DIFF
--- a/app/org/hadatac/console/controllers/dataacquisitionsearch/DataAcquisitionSearch.java
+++ b/app/org/hadatac/console/controllers/dataacquisitionsearch/DataAcquisitionSearch.java
@@ -19,6 +19,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.concurrent.ExecutionException;
 
+import org.hadatac.console.http.SPARQLUtilsFacetSearch;
 import org.hadatac.console.models.FacetFormData;
 import org.hadatac.console.models.FacetHandler;
 import org.hadatac.console.models.FacetsWithCategories;
@@ -96,6 +97,7 @@ public class DataAcquisitionSearch extends Controller {
     public Result index(int page, int rows) {
         if ( "ON".equalsIgnoreCase(ConfigFactory.load().getString("hadatac.facet_search.concurrency")) ) {
             log.debug("using async calls for facet search....");
+            SPARQLUtilsFacetSearch.clearCache();
             return indexInternalAsync(0, page, rows);
         } else {
             return indexInternal(0, page, rows);

--- a/app/org/hadatac/console/http/SPARQLUtilsFacetSearch.java
+++ b/app/org/hadatac/console/http/SPARQLUtilsFacetSearch.java
@@ -1,0 +1,97 @@
+package org.hadatac.console.http;
+
+import com.typesafe.config.ConfigFactory;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.query.QueryParseException;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.ResultSetFactory;
+import org.apache.jena.query.ResultSetRewindable;
+import org.apache.jena.rdf.model.Model;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Singleton;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Singleton
+public class SPARQLUtilsFacetSearch {
+
+    private static final Logger log = LoggerFactory.getLogger(SPARQLUtilsFacetSearch.class);
+    private static Set<String> visited = new HashSet<>();
+
+    private static ConcurrentHashMap<String, ResultSetRewindable> selectCache = new ConcurrentHashMap<>();
+    private static ConcurrentHashMap<String, Model> describeCache = new ConcurrentHashMap<>();
+
+    public static void clearCache() {
+        selectCache.clear();
+        describeCache.clear();
+        visited.clear();
+    }
+
+    public static ResultSetRewindable select(String sparqlService, String queryString) {
+        // System.out.println("\nqueryString: " + queryString + "\n");
+
+        /*log.info("in SPARQLUtilsFacetSearch.select");
+        if ( visited.contains(queryString) ) {
+            log.info("encountered!!!!!!");
+        } else {
+            visited.add(queryString);
+        }*/
+
+        if ( "ON".equalsIgnoreCase(ConfigFactory.load().getString("hadatac.facet_search.readOnlyMode")) ) {
+            if (selectCache.containsKey(queryString)) {
+                return selectCache.get(queryString);
+            }
+        }
+
+        try {
+            Query query = QueryFactory.create(queryString);
+            QueryExecution qexec = QueryExecutionFactory.sparqlService(sparqlService, query);
+            ResultSet results = qexec.execSelect();
+            ResultSetRewindable resultsrw = ResultSetFactory.copyResults(results);
+            qexec.close();
+            if ( "ON".equalsIgnoreCase(ConfigFactory.load().getString("hadatac.facet_search.readOnlyMode")) ) {
+                selectCache.put(queryString,resultsrw);
+            }
+            return resultsrw;
+        } catch (QueryParseException e) {
+            System.out.println("[ERROR] queryString: " + queryString);
+            throw e;
+        }
+    }
+
+    public static Model describe(String sparqlService, String queryString) {
+        // System.out.println("\nqueryString: " + queryString + "\n");
+        /*log.info("in SPARQLUtilsFacetSearch.describe");
+        if ( visited.contains(queryString) ) {
+            log.info("describe encountered!!!!!!");
+        } else {
+            visited.add(queryString);
+        }*/
+
+        if ( "ON".equalsIgnoreCase(ConfigFactory.load().getString("hadatac.facet_search.readOnlyMode")) ) {
+            if (describeCache.containsKey(queryString)) {
+                return describeCache.get(queryString);
+            }
+        }
+
+        try {
+            Query query = QueryFactory.create(queryString);
+            QueryExecution qexec = QueryExecutionFactory.sparqlService(sparqlService, query);
+            Model model = qexec.execDescribe();
+            qexec.close();
+            if ( "ON".equalsIgnoreCase(ConfigFactory.load().getString("hadatac.facet_search.readOnlyMode")) ) {
+                describeCache.put(queryString, model);
+            }
+            return model;
+        } catch (QueryParseException e) {
+            System.out.println("[ERROR] queryString: " + queryString);
+            throw e;
+        }
+    }
+}

--- a/app/org/hadatac/entity/pojo/AttributeInstance.java
+++ b/app/org/hadatac/entity/pojo/AttributeInstance.java
@@ -19,10 +19,13 @@ import org.hadatac.console.models.Facetable;
 import org.hadatac.console.models.Pivot;
 import org.hadatac.console.models.Facet;
 import org.hadatac.utils.CollectionUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class AttributeInstance extends HADatAcThing implements Comparable<AttributeInstance> {
 
+    private static final Logger log = LoggerFactory.getLogger(AttributeInstance.class);
     static String className = "sio:SIO_000614";
 
     public AttributeInstance () {}
@@ -77,7 +80,7 @@ public class AttributeInstance extends HADatAcThing implements Comparable<Attrib
     @Override
     public Map<Facetable, List<Facetable>> getTargetFacetsFromSolr(
             Facet facet, FacetHandler facetHandler) {
-        
+
         SolrQuery query = new SolrQuery();
         QueryResponse queryResponse = null;
         String strQuery = facetHandler.getTempSolrQuery(facet);
@@ -117,11 +120,11 @@ public class AttributeInstance extends HADatAcThing implements Comparable<Attrib
             if (pivot_ent.getValue().contains("; ")) {
                 List<String> uris = Arrays.asList(pivot_ent.getValue().split("; "));
                 String label = String.join(" ", uris.stream()
-                        .map(s -> WordUtils.capitalize(Attribute.find(s).getLabel()))
+                        .map(s -> WordUtils.capitalize(Attribute.facetSearchFind(s).getLabel()))
                         .collect(Collectors.toList()));
                 attrib.setLabel(label);
             } else {
-                attrib.setLabel(WordUtils.capitalize(Attribute.find(pivot_ent.getValue()).getLabel()));
+                attrib.setLabel(WordUtils.capitalize(Attribute.facetSearchFind(pivot_ent.getValue()).getLabel()));
             }
             attrib.setCount(pivot_ent.getCount());
             attrib.setQuery(query);

--- a/app/org/hadatac/entity/pojo/DASEType.java
+++ b/app/org/hadatac/entity/pojo/DASEType.java
@@ -9,15 +9,19 @@ import org.apache.commons.text.WordUtils;
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSetRewindable;
 import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
-import org.hadatac.console.http.SPARQLUtils;
+import org.hadatac.console.http.SPARQLUtilsFacetSearch;
 import org.hadatac.console.models.Facet;
 import org.hadatac.console.models.FacetHandler;
 import org.hadatac.console.models.Facetable;
 import org.hadatac.utils.CollectionUtil;
 import org.hadatac.utils.NameSpaces;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class DASEType extends HADatAcThing implements Comparable<DASEType> {
+
+    private static final Logger log = LoggerFactory.getLogger(DASEType.class);
 
     public DASEType() {}
 
@@ -44,7 +48,7 @@ public class DASEType extends HADatAcThing implements Comparable<DASEType> {
     @Override
     public Map<Facetable, List<Facetable>> getTargetFacetsFromTripleStore(
             Facet facet, FacetHandler facetHandler) {
-        
+
         String valueConstraint = "";
         if (!facet.getFacetValuesByField("dase_type_uri_str").isEmpty()) {
             valueConstraint += " VALUES ?daseTypeUri { " + stringify(
@@ -72,7 +76,7 @@ public class DASEType extends HADatAcThing implements Comparable<DASEType> {
         
         Map<Facetable, List<Facetable>> mapTypeToInstanceList = new HashMap<Facetable, List<Facetable>>();
         try {
-            ResultSetRewindable resultsrw = SPARQLUtils.select(
+            ResultSetRewindable resultsrw = SPARQLUtilsFacetSearch.select(
                     CollectionUtil.getCollectionPath(CollectionUtil.Collection.METADATA_SPARQL), query);
             while (resultsrw.hasNext()) {
                 QuerySolution soln = resultsrw.next();

--- a/app/org/hadatac/entity/pojo/EntityInstance.java
+++ b/app/org/hadatac/entity/pojo/EntityInstance.java
@@ -17,10 +17,13 @@ import org.hadatac.console.models.FacetHandler;
 import org.hadatac.console.models.Facetable;
 import org.hadatac.console.models.Pivot;
 import org.hadatac.utils.CollectionUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class EntityInstance extends HADatAcThing implements Comparable<EntityInstance> {
 
+    private static final Logger log = LoggerFactory.getLogger(EntityInstance.class);
     static String className = "sio:SIO_000776";
 
     public EntityInstance() {}
@@ -109,7 +112,7 @@ public class EntityInstance extends HADatAcThing implements Comparable<EntityIns
         for (Pivot pivot_ent : pivot.children) {
             EntityInstance entity = new EntityInstance();
             entity.setUri(pivot_ent.getValue());
-            entity.setLabel("[" + WordUtils.capitalize(Entity.find(pivot_ent.getValue()).getLabel()) + "]");
+            entity.setLabel("[" + WordUtils.capitalize(Entity.facetSearchFind(pivot_ent.getValue()).getLabel()) + "]");
             entity.setCount(pivot_ent.getCount());
             entity.setField("entity_uri_str");
             entity.setQuery(query);

--- a/app/org/hadatac/entity/pojo/EntityRole.java
+++ b/app/org/hadatac/entity/pojo/EntityRole.java
@@ -14,6 +14,7 @@ import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.hadatac.console.http.SPARQLUtils;
+import org.hadatac.console.http.SPARQLUtilsFacetSearch;
 import org.hadatac.console.models.Facet;
 import org.hadatac.console.models.FacetHandler;
 import org.hadatac.console.models.Facetable;
@@ -21,8 +22,12 @@ import org.hadatac.console.models.Pivot;
 import org.hadatac.metadata.loader.URIUtils;
 import org.hadatac.utils.CollectionUtil;
 import org.hadatac.utils.NameSpaces;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class EntityRole extends HADatAcThing implements Comparable<EntityRole> {
+
+    private static final Logger log = LoggerFactory.getLogger(EntityRole.class);
 
     static String className = "sio:SIO_000776";
 
@@ -98,7 +103,7 @@ public class EntityRole extends HADatAcThing implements Comparable<EntityRole> {
 
         Map<Facetable, List<Facetable>> results = new HashMap<Facetable, List<Facetable>>();
         try {
-            ResultSetRewindable resultsrw = SPARQLUtils.select(
+            ResultSetRewindable resultsrw = SPARQLUtilsFacetSearch.select(
                     CollectionUtil.getCollectionPath(CollectionUtil.Collection.METADATA_SPARQL), query);
 
             if (resultsrw.size() == 0) {

--- a/app/org/hadatac/entity/pojo/Indicator.java
+++ b/app/org/hadatac/entity/pojo/Indicator.java
@@ -24,6 +24,7 @@ import org.apache.jena.update.UpdateProcessor;
 import org.apache.jena.update.UpdateRequest;
 import org.hadatac.console.controllers.metadata.DynamicFunctions;
 import org.hadatac.console.http.SPARQLUtils;
+import org.hadatac.console.http.SPARQLUtilsFacetSearch;
 import org.hadatac.console.models.Facet;
 import org.hadatac.console.models.FacetHandler;
 import org.hadatac.console.models.Facetable;
@@ -31,8 +32,12 @@ import org.hadatac.console.models.Pivot;
 import org.hadatac.metadata.loader.URIUtils;
 import org.hadatac.utils.CollectionUtil;
 import org.hadatac.utils.NameSpaces;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Indicator extends HADatAcThing implements Comparable<Indicator> {
+
+    private static final Logger log = LoggerFactory.getLogger(Indicator.class);
 
     public static String INSERT_LINE1 = "INSERT DATA {  ";
     public static String DELETE_LINE1 = "DELETE WHERE {  ";
@@ -569,7 +574,7 @@ public class Indicator extends HADatAcThing implements Comparable<Indicator> {
         
         Map<Facetable, List<Facetable>> mapIndicatorToCharList = new HashMap<Facetable, List<Facetable>>();
         try {
-            ResultSetRewindable resultsrw = SPARQLUtils.select(
+            ResultSetRewindable resultsrw = SPARQLUtilsFacetSearch.select(
                     CollectionUtil.getCollectionPath(CollectionUtil.Collection.METADATA_SPARQL), query);
 
             while (resultsrw.hasNext()) {
@@ -577,7 +582,7 @@ public class Indicator extends HADatAcThing implements Comparable<Indicator> {
                 Indicator indicator = new Indicator();
                 indicator.setUri(soln.get("indicator").toString());
                 //System.out.println("Indicator.getTargetFacets(): identified indicator [" + indicator.getUri() + "]  label: [" + indicator.getLabel() + "]");
-                indicator.setLabel(WordUtils.capitalize(HADatAcThing.getShortestLabel(soln.get("indicator").toString())));
+                indicator.setLabel(WordUtils.capitalize(HADatAcThing.getFacetSearchShortestLabel(soln.get("indicator").toString())));
                 indicator.setField("indicator_uri_str");
                 indicator.setQuery(query);
 

--- a/app/org/hadatac/entity/pojo/Instrument.java
+++ b/app/org/hadatac/entity/pojo/Instrument.java
@@ -17,14 +17,18 @@ import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
 import org.hadatac.console.http.SPARQLUtils;
+import org.hadatac.console.http.SPARQLUtilsFacetSearch;
 import org.hadatac.console.models.Facet;
 import org.hadatac.console.models.FacetHandler;
 import org.hadatac.console.models.Facetable;
 import org.hadatac.utils.CollectionUtil;
 import org.hadatac.utils.NameSpaces;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Instrument extends HADatAcThing implements Comparable<Instrument> {
 
+	private static final Logger log = LoggerFactory.getLogger(Instrument.class);
 	private String serialNumber;
 	private String image;
 	
@@ -129,7 +133,7 @@ public class Instrument extends HADatAcThing implements Comparable<Instrument> {
 		
 		Map<Facetable, List<Facetable>> results = new HashMap<Facetable, List<Facetable>>();
 		try {
-		    ResultSetRewindable resultsrw = SPARQLUtils.select(
+		    ResultSetRewindable resultsrw = SPARQLUtilsFacetSearch.select(
 	                CollectionUtil.getCollectionPath(CollectionUtil.Collection.METADATA_SPARQL), query);
 		    
 			while (resultsrw.hasNext()) {

--- a/app/org/hadatac/entity/pojo/ObjectCollectionType.java
+++ b/app/org/hadatac/entity/pojo/ObjectCollectionType.java
@@ -17,6 +17,7 @@ import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
+import org.hadatac.console.http.SPARQLUtilsFacetSearch;
 import org.hadatac.utils.CollectionUtil;
 import org.hadatac.utils.NameSpaces;
 import org.hadatac.console.http.SPARQLUtils;
@@ -24,9 +25,13 @@ import org.hadatac.console.models.Facet;
 import org.hadatac.console.models.FacetHandler;
 import org.hadatac.console.models.Facetable;
 import org.hadatac.metadata.loader.URIUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class ObjectCollectionType extends HADatAcClass implements Comparable<ObjectCollectionType> {
+
+	private static final Logger log = LoggerFactory.getLogger(ObjectCollection.class);
 
 	static String className = "hasco:ObjectCollection";
 	String studyObjectTypeUri = "";
@@ -166,7 +171,7 @@ public class ObjectCollectionType extends HADatAcClass implements Comparable<Obj
 
         Map<Facetable, List<Facetable>> results = new HashMap<Facetable, List<Facetable>>();
         try {            
-            ResultSetRewindable resultsrw = SPARQLUtils.select(
+            ResultSetRewindable resultsrw = SPARQLUtilsFacetSearch.select(
                     CollectionUtil.getCollectionPath(CollectionUtil.Collection.METADATA_SPARQL), query);
 
             while (resultsrw.hasNext()) {

--- a/app/org/hadatac/entity/pojo/Platform.java
+++ b/app/org/hadatac/entity/pojo/Platform.java
@@ -17,6 +17,7 @@ import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
+import org.hadatac.console.http.SPARQLUtilsFacetSearch;
 import org.hadatac.utils.CollectionUtil;
 import org.hadatac.utils.FirstLabel;
 import org.hadatac.utils.NameSpaces;
@@ -28,10 +29,13 @@ import org.hadatac.console.models.Facet;
 import org.hadatac.console.models.FacetHandler;
 import org.hadatac.console.models.Facetable;
 import org.hadatac.metadata.loader.URIUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Platform extends HADatAcThing implements Comparable<Platform> {
 
-	public static String LAT = "http://semanticscience.org/resource/Latitude";
+    private static final Logger log = LoggerFactory.getLogger(Platform.class);
+    public static String LAT = "http://semanticscience.org/resource/Latitude";
 	public static String LONG = "http://semanticscience.org/resource/Longitude";
 	
 	public static String INSERT_LINE1 = "INSERT DATA {  ";
@@ -402,7 +406,7 @@ public class Platform extends HADatAcThing implements Comparable<Platform> {
 
         Map<Facetable, List<Facetable>> results = new HashMap<Facetable, List<Facetable>>();
         try {
-            ResultSetRewindable resultsrw = SPARQLUtils.select(
+            ResultSetRewindable resultsrw = SPARQLUtilsFacetSearch.select(
                     CollectionUtil.getCollectionPath(CollectionUtil.Collection.METADATA_SPARQL), query);
             
             while (resultsrw.hasNext()) {

--- a/app/org/hadatac/entity/pojo/Study.java
+++ b/app/org/hadatac/entity/pojo/Study.java
@@ -24,6 +24,7 @@ import org.hadatac.annotations.PropertyField;
 import org.hadatac.annotations.PropertyValueType;
 import org.hadatac.console.controllers.metadata.DynamicFunctions;
 import org.hadatac.console.http.SPARQLUtils;
+import org.hadatac.console.http.SPARQLUtilsFacetSearch;
 import org.hadatac.console.models.Facet;
 import org.hadatac.console.models.FacetHandler;
 import org.hadatac.console.models.Facetable;
@@ -36,9 +37,13 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class Study extends HADatAcThing {
+
+    private static final Logger log = LoggerFactory.getLogger(Study.class);
 
     private static String className = "hasco:Study";
 
@@ -417,7 +422,7 @@ public class Study extends HADatAcThing {
 
         Map<Facetable, List<Facetable>> results = new HashMap<Facetable, List<Facetable>>();
         try {
-            ResultSetRewindable resultsrw = SPARQLUtils.select(
+            ResultSetRewindable resultsrw = SPARQLUtilsFacetSearch.select(
                     CollectionUtil.getCollectionPath(CollectionUtil.Collection.METADATA_SPARQL), query);
 
             while (resultsrw.hasNext()) {

--- a/app/org/hadatac/entity/pojo/StudyObjectType.java
+++ b/app/org/hadatac/entity/pojo/StudyObjectType.java
@@ -18,14 +18,19 @@ import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
 import org.hadatac.console.http.SPARQLUtils;
+import org.hadatac.console.http.SPARQLUtilsFacetSearch;
 import org.hadatac.console.models.Facet;
 import org.hadatac.console.models.FacetHandler;
 import org.hadatac.console.models.Facetable;
 import org.hadatac.utils.CollectionUtil;
 import org.hadatac.utils.NameSpaces;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class StudyObjectType extends HADatAcClass implements Comparable<StudyObjectType> {
+
+    private static final Logger log = LoggerFactory.getLogger(StudyObjectType.class);
 
     static String className = "hasco:StudyObject";
 
@@ -125,7 +130,7 @@ public class StudyObjectType extends HADatAcClass implements Comparable<StudyObj
 
         Map<Facetable, List<Facetable>> results = new HashMap<Facetable, List<Facetable>>();
         try {            
-            ResultSetRewindable resultsrw = SPARQLUtils.select(
+            ResultSetRewindable resultsrw = SPARQLUtilsFacetSearch.select(
                     CollectionUtil.getCollectionPath(CollectionUtil.Collection.METADATA_SPARQL), query);
 
             while (resultsrw.hasNext()) {


### PR DESCRIPTION
this is to use a local cache to store the search results, so when the same search is submitted, the result in the cache can be returned without going to the backend server. NOTE this is only used for facet search (a read-only mode).