### PR TITLE
use SPARQLUtilsFacetSearch before refactoring

### DIFF
--- a/app/module/OnStart.java
+++ b/app/module/OnStart.java
@@ -8,7 +8,7 @@ import javax.inject.Singleton;
 
 import org.hadatac.console.models.SecurityRole;
 import org.hadatac.data.loader.mqtt.MqttMessageWorker;
-import org.hadatac.entity.pojo.SPARQLUtilsFacetSearch;
+import org.hadatac.console.http.SPARQLUtilsFacetSearch;
 import org.hadatac.utils.CollectionUtil;
 
 import org.hadatac.utils.ConfigProp;


### PR DESCRIPTION
need to use this:
`import org.hadatac.console.http.SPARQLUtilsFacetSearch;`
instead of using this:
`import org.hadatac.entity.pojo.SPARQLUtilsFacetSearch`
because in release branch we have not done refactoring yet.