### PR TITLE
HHEAR-651:Labels and Comments for SOCs Include Study ID When URIs Don't

### DIFF
--- a/app/org/hadatac/data/loader/DASOInstanceGenerator.java
+++ b/app/org/hadatac/data/loader/DASOInstanceGenerator.java
@@ -1,5 +1,6 @@
 package org.hadatac.data.loader;
 
+import com.typesafe.config.ConfigFactory;
 import org.hadatac.entity.pojo.DataAcquisitionSchema;
 import org.hadatac.entity.pojo.DataAcquisitionSchemaAttribute;
 import org.hadatac.entity.pojo.DataAcquisitionSchemaObject;
@@ -921,6 +922,9 @@ public class DASOInstanceGenerator extends BaseGenerator {
             labelPrefix = "SBJ ";
         } else {
             labelPrefix = "SPL ";
+        }
+        if ( labelPrefix.contains("SBJ") && "ON".equalsIgnoreCase(ConfigFactory.load().getString("hadatac.graph.uniqueIdentifiers")) ) {
+            return labelPrefix + originalID;
         }
         return labelPrefix + originalID + " - " + socIdFromUri(soc.getUri());
 

--- a/app/org/hadatac/data/loader/StudyObjectGenerator.java
+++ b/app/org/hadatac/data/loader/StudyObjectGenerator.java
@@ -107,7 +107,10 @@ public class StudyObjectGenerator extends BaseGenerator {
         } else {
             auxstr = auxstr.replaceAll("-","");
         }
-        
+
+        if ( auxstr.contains("SBJ") && "ON".equalsIgnoreCase(ConfigFactory.load().getString("hadatac.graph.uniqueIdentifiers")) ) {
+            return auxstr + " " + originalID;
+        }
         return auxstr + " " + originalID + " - " + study_id;
     }
 


### PR DESCRIPTION
After making the change so that the URIs for SOC members do not have the study IDs included in them, it seems the labels and comments being generated for these terms still include the Study ID. This fix is to read the config settings and depends on the settings, we will remove the Study ID from the generated labels and comments.  