### PR TITLE
HHEAR-729:fix a few issues discovered in QA testing

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -105,3 +105,8 @@ database.dispatcher {
         fixed-pool-size = 40
     }
 }
+
+#for submitting form data
+play.http.parser.maxDiskBuffer = 100MB
+play.http.parser.maxMemoryBuffer = 64MB
+parsers.anyContent.maxLength = 100MB

--- a/solr/solr-home/csv/conf/schema.xml
+++ b/solr/solr-home/csv/conf/schema.xml
@@ -2,6 +2,7 @@
 <schema version="1.5">
   <fields>
     <field name="id" type="string" stored="true" indexed="true" docValues="true" />
+    <field name="log_str" type="text_general" indexed="false" stored="true" />
     <dynamicField name="*_str" type="string" indexed="true" stored="true" docValues="true"/>
     <dynamicField name="*_str_multi" type="string" indexed="true" stored="true" docValues="true" multiValued="true" />
     <dynamicField name="*_date" type="date" indexed="true" stored="true" docValues="true"/>

--- a/solr/solr-home/user_search_activities/conf/schema.xml
+++ b/solr/solr-home/user_search_activities/conf/schema.xml
@@ -2,6 +2,7 @@
 <schema version="1.5">
   <fields>
     <field name="id" type="string" indexed="true" stored="true"/>
+    <field name="json_query_str" type="text_general" indexed="false" stored="true" />
     <dynamicField name="*_str" type="string" indexed="true" stored="true" docValues="true"/>
     <dynamicField name="*_str_multi" type="string" indexed="true" stored="true" docValues="true" multiValued="true" />
     <dynamicField name="*_date" type="date" indexed="true" stored="true" docValues="true"/>


### PR DESCRIPTION
this is to fix the following issues discovered in QA testing:
1. some facet search will produce "Data Request Object too big" error message
2. some dataset generation will result in a 0% generation progress indicator which never progresses
3. some facet search will produce error in the log. The log is like this: 

`2021-09-13 17:34:20 +0000 [ERROR] from org.hadatac.console.models.UserSearchActivity in application-akka.actor.default-dispatcher-11 - errors when saving to Solr: Error from server at http://solr:8983/solr/user_search_activities: Exception writing document id f86f945c-23f7-4e3f-b95c-144b5ef384c3 to the index; possible analysis error: Document contains at least one immense term in field="json_query_str" (whose UTF8 encoding is longer than the max length 32766), all of which were skipped. Please correct the analyzer to not produce such terms. The prefix of the first immense term is: '[123, 34, 102, 97, 99, 101, 116, 115, 69, 67, 34, 58, 91, 123, 34, 105, 100, 34, 58, 34, 104, 116, 116, 112, 58, 47, 47, 112, 117, 114]...', original message: bytes can be at most 32766 in length; got 56202. Perhaps the document has an indexed string field (solr.StrField) which is too large`