### PR TITLE
HHEAR-729: hide Browse Metedata

### DIFF
--- a/app/org/hadatac/console/views/main.scala.html
+++ b/app/org/hadatac/console/views/main.scala.html
@@ -48,7 +48,7 @@
                 <div id="navbar" class="navbar-collapse collapse">
                     <ul class="nav navbar-nav">
                         <li><a href="@org.hadatac.console.controllers.dataacquisitionsearch.routes.DataAcquisitionSearch.index()">Search Data</a></li>
-                         <li><a href="@org.hadatac.console.controllers.metadata.routes.Metadata.index()">Browse Metadata</a></li>
+                        @* <li><a href="@org.hadatac.console.controllers.metadata.routes.Metadata.index()">Browse Metadata</a></li>  *@
                         <li><a href="@org.hadatac.console.controllers.routes.Dashboard.index()">Dashboard</a></li>
                         @* @if(org.hadatac.utils.CollectionUtil.isSandboxMode()) {
                             <li><a style="background-color: #ffff00" href="@org.hadatac.console.controllers.sandbox.routes.Sandbox.index()">Sandbox Mode</a></li>


### PR DESCRIPTION
this is a single line change for GUI to hide the "Browse Metedata" button, based on the request from Jeanette.