### PR TITLE
set named graph for hasRoleLabel for SSD

### DIFF
--- a/app/org/hadatac/data/loader/SSDGeneratorChain.java
+++ b/app/org/hadatac/data/loader/SSDGeneratorChain.java
@@ -20,6 +20,7 @@ public class SSDGeneratorChain extends GeneratorChain {
                 getDataFile().getLogger().println("Label for " + oc.getSOCReference() + ": ERROR could not find path to colletion with grounding label");
             } else {
                 getDataFile().getLogger().println("Label for " + oc.getSOCReference() + ": " + labelResult);
+                oc.setNamedGraph(getNamedGraphUri());
                 oc.saveRoleLabel(labelResult);
             }
         } 

--- a/app/org/hadatac/entity/pojo/ObjectCollection.java
+++ b/app/org/hadatac/entity/pojo/ObjectCollection.java
@@ -1345,15 +1345,19 @@ public class ObjectCollection extends HADatAcThing implements Comparable<ObjectC
 
         insert += NameSpaces.getInstance().printSparqlNameSpaceList();
         insert += INSERT_LINE1;
-        if (uri.startsWith("http")) {
+        if(!getNamedGraph().isEmpty()){
             insert += "graph  <"+getNamedGraph()+"> { " ;
+        }
+        if (uri.startsWith("http")) {
             insert += "  <" + uri + "> hasco:hasRoleLabel \"" + label + "\" . ";
 
         } else {
-            insert += "graph  <"+getNamedGraph()+"> { " ;
             insert += "  " + uri + " hasco:hasRoleLabel \"" + label + "\" . ";
         }
-        insert += LINE_LAST+LINE_LAST;
+        insert += LINE_LAST;
+        if(!getNamedGraph().isEmpty()){
+            insert += LINE_LAST;
+        }
         UpdateRequest request = UpdateFactory.create(insert);
         UpdateProcessor processor = UpdateExecutionFactory.createRemote(
                 request, CollectionUtil.getCollectionPath(CollectionUtil.Collection.METADATA_UPDATE));


### PR DESCRIPTION
Fix added for  hasco:hasRoleLabel triples that are added for SOCs defined in the SSD files are added using a bad graph name.