### PR TITLE
HHEAR-815: Determine how to replace default number on Study Search Interface

### DIFF
--- a/public/javascripts/jquery.facetview.js
+++ b/public/javascripts/jquery.facetview.js
@@ -1309,8 +1309,8 @@ search box - the end user will not know they are happening.
             for (var item in options.facets) {
                 urlfilters += "facet.field=" + options.facets[item]['field'] + "&";
                 //prompt('options.facets[item][\'size\'] = ' + options.facets[item]['size'] );
-                //var size = options.facets[item]['size'] ? options.facets[item]['size'] : 5;
-                // urlfilters += "f." + options.facets[item]['field'] + ".facet.limit=" + size + "&";
+                var size = options.facets[item]['size'] ? options.facets[item]['size'] : 10000;
+                urlfilters += "f." + options.facets[item]['field'] + ".facet.limit=" + size + "&";
 		var sort = 'count';
 		if (options.facets[item]['order']) {
 		    sort = options.facets[item]['order'];

--- a/public/javascripts/jquery.facetview.js
+++ b/public/javascripts/jquery.facetview.js
@@ -594,8 +594,8 @@ search box - the end user will not know they are happening.
                         style="color:#333; font-weight:bold;" href=""><i class="icon-plus"></i> {{FILTER_DISPLAY}} \
                         </a> \
                         <div class="btn-group facetview_filteroptions" style="display:none; margin-top:5px;"> \
-                            <a class="btn btn-small facetview_learnmore" title="click to view search help information" href="#"><b>?</b></a> \
-                            <a class="btn btn-small facetview_morefacetvals" title="filter list size" rel="{{FACET_IDX}}" href="{{FILTER_EXACT}}">{{FILTER_HOWMANY}}</a> \
+                            <!-- <a class="btn btn-small facetview_learnmore" title="click to view search help information" href="#"><b>?</b></a> --> \
+                            <!-- <a class="btn btn-small facetview_morefacetvals" title="click this number to change how many indicators you would like to display here" rel="{{FACET_IDX}}" href="{{FILTER_EXACT}}">{{FILTER_HOWMANY}}</a>  -->\
                             <a class="btn btn-small facetview_sort {{FILTER_SORTTERM}}" title="filter value order" href="{{FILTER_EXACT}}">{{FILTER_SORTCONTENT}}</a> \
                             <a class="btn btn-small facetview_or" title="select another option from this filter" rel="AND" href="{{FILTER_EXACT}}" style="color:#aaa;">OR</a> \
                             ';
@@ -922,12 +922,14 @@ search box - the end user will not know they are happening.
         if (facet == options.dendrogram_field){
             dendrogramFacet = true;
         }
-    
+
+        var cnt = 0;
         for ( var item in records ) {
             var append = '<tr class="facetview_filtervalue" style="display:none;"><td><a class="facetview_filterchoice' +
                 '" rel="' + facet + '" href="' + item + '">' + item +
                 ' (' + records[item] + ')</a></td></tr>';
             facet_filter.append(append);
+            cnt++;
 
             if (lineChartFacet){
                 years.push(item);
@@ -936,6 +938,11 @@ search box - the end user will not know they are happening.
 
             }
 
+            if ( cnt > 0 ) {
+                const currentTitle = facet_filter.children().find('.facetview_filtershow').get(0).innerText;
+                if ( currentTitle.includes("variable count") == false )
+                    facet_filter.children().find('.facetview_filtershow').append(" (variable count:" + cnt + ")");
+            }
             if ( $('.facetview_filtershow[rel="' + facetclean + '"]', obj).hasClass('facetview_open') ) {
                 facet_filter.children().find('.facetview_filtervalue').show();
             }
@@ -1301,8 +1308,9 @@ search box - the end user will not know they are happening.
             var urlfilters = "";
             for (var item in options.facets) {
                 urlfilters += "facet.field=" + options.facets[item]['field'] + "&";
-                var size = options.facets[item]['size'] ? options.facets[item]['size'] : 10;
-                urlfilters += "f." + options.facets[item]['field'] + ".facet.limit=" + size + "&";
+                //prompt('options.facets[item][\'size\'] = ' + options.facets[item]['size'] );
+                //var size = options.facets[item]['size'] ? options.facets[item]['size'] : 5;
+                // urlfilters += "f." + options.facets[item]['field'] + ".facet.limit=" + size + "&";
 		var sort = 'count';
 		if (options.facets[item]['order']) {
 		    sort = options.facets[item]['order'];


### PR DESCRIPTION
This is to 1). hide the "?" button on the study search page, 2). to show all the variables under one indicator, and also add the total number of variables on the indicator display, 3). remove the "10" button since we are going to show all the available results. Only one file is changed and no backend changes.